### PR TITLE
review of using sugar and activities sections

### DIFF
--- a/source/collaborating.rst
+++ b/source/collaborating.rst
@@ -5,7 +5,7 @@ Collaborating
 About Collaborating
 -------------------
 
-One of the most important features of Sugar is the ability for you to collaborate, or network, and share a project that you are working on with others. This can take the form of multiple cursors in a document, multiple musical instruments, two players in a game, multiple uses in chat (below), and so on. Many Activities support collaboration, see below, :ref:`Where to get Collaborating`
+One of the most important features of Sugar is the ability for you to collaborate, or network, and share a project that you are working on with others. This can take the form of multiple cursors in a document, multiple musical instruments, two players in a game, multiple uses in chat, and so on. Many Activities support collaboration, see below, :ref:`Where to get Collaborating`.
 
 This image is from the Activity toolbar of Write, which is an Activity which supports collaboration.
 
@@ -48,7 +48,7 @@ This will make it available to all other persons connected to your same Ad-hock 
 Where to get Collaborating
 --------------------------
 
-Collaborating is a built-in function in the following Activities provided in the current Sugar distribution:
+Collaborating is a built-in function in the following Activities:
 
 * Browse
 * Calculate

--- a/source/exiting_activities.rst
+++ b/source/exiting_activities.rst
@@ -2,16 +2,16 @@
 Exiting Activities
 ==================
 
-To Exit an Activity, use the touchpad or a mouse to move the cursor to the close box on the right corner of the Frame and click. Try to have no more than three Activities open at once.
+To stop an Activity, use the touchpad or a mouse to move the cursor to the stop button on the right corner and click. Try to have no more than three Activities open at once.
 
 .. image :: ../images/CLOSEBUTTON.jpg
 
-To quit an Activity using a keyboard shortcut, press and hold the **ctrl** key, and then press the **q** key.
+To stop an Activity using the keyboard, press and hold the **ctrl** key, and then press the **q** key.  There are some exceptions below.
 
 Scratch
 -------
 
-There are some "Activities", such as Scratch, that are closed from the "File" menu by selecting "Quit" or "Exit". These activities may require a separate step to save your work by clicking on the "save" or "save as" command or may also be done by clicking the folder icon with a downpointing arrow.
+There are some "Activities", such as Scratch, that are stopped from the "File" menu by selecting "Quit" or "Exit". These activities may require a separate step to save your work by clicking on the "Save" or "Save As" command or may also be done by clicking the folder icon with a downpointing arrow.
 
 In Scratch, for example, you must go to "File" then "Save As" then give your project a name next to "New Filename" then click "OK".
 
@@ -20,5 +20,9 @@ In Scratch, for example, you must go to "File" then "Save As" then give your pro
 Etoys
 -----
 
-The Etoys Activity closes by clicking a button that has an ✕ within a white disc, rather than the stop sign.
+The Etoys Activity is stopped by clicking a button that has an ✕ within a white disc, rather than the stop sign.
 
+Terminal
+--------
+
+The Terminal Activity must be quit using Ctrl/D, Ctrl/Shift/Q, or the stop button.  This is because Ctrl/Q has a special meaning in a Terminal.

--- a/source/frame.rst
+++ b/source/frame.rst
@@ -12,7 +12,7 @@ You can access the frame from any view in 2 ways:
 - By using the Frame Key on the keyboard. On XO laptops the Frame key is the square icon on the upper right hand corner of your keyboard, on other laptops you can use the F6 key.
 - By moving the cursor to the edges or corners of your screen. (There are several options you can configure in this area, please refer to the My Settings section for more details.) 
 
-In the XO-4, with touch screen, is possible show the frame sliding a finger, from the top of the screen, a few centimeters. The same gesture will hide the frame too.
+In the XO-4, with touch screen, you may show the frame by sliding a finger, from the top of the screen, a few centimeters downward. The same gesture will hide the frame too.
 
 Frame Elements
 --------------

--- a/source/gnome.rst
+++ b/source/gnome.rst
@@ -4,18 +4,20 @@ GNOME
 
 In late 2009 OLPC added a more conventional desktop environment called GNOME to its operating system. This is intended for older children and advanced users.
 
+In late 2014 OLPC switched to MATE desktop, which is what GNOME was like before GNOME began some very serious changes.
+
 .. image :: ../images/Gnome-desktop.jpg
 
 
-Users can switch from Sugar to GNOME through the Switch Desktop option under My Settings.
+Users can switch from Sugar to GNOME or MATE through the Switch Desktop option under My Settings.
 
 .. image :: ../images/Gnome-control_panel.png
 
-After selecting the Switch Desktop option another confirmation dialogue with additional information appears. The switch to GNOME can be initiated by clicking the Restart now button.
+After selecting the Switch Desktop option another confirmation dialogue with additional information appears. The switch can be confirmed by clicking the Restart now button.
 
 .. image :: ../images/Gnome-confirmation.png
 
-Switching back to Sugar from GNOME can be done via the Switch to Sugar icon on the GNOME desktop or the Application - System Tools menu and confirming the corresponding message box.
+Switching back to Sugar can be done via the Switch to Sugar icon on the desktop or the Application - System Tools menu and confirming the corresponding message box.
 
 .. image :: ../images/Gnome-switch_back.jpg
 

--- a/source/home_view.rst
+++ b/source/home_view.rst
@@ -30,7 +30,7 @@ Favorites View
 
 .. image:: ../images/Home_fav-search.png
 
-When a search is started the Activities which don't correspond to the result are greyed out.
+When a search is done the Activities which don't correspond to the result are greyed out.  If only one Activity matches the search, the full name will replace what has been typed, and pressing enter will launch the Activity.
 
 List View
 ---------

--- a/source/journal.rst
+++ b/source/journal.rst
@@ -13,9 +13,9 @@ Accessing the Journal
 
 .. image:: ../images/Journal_home.png
 
-To show the Journal, click the Journal icon on the Frame.
+To show the Journal, click the Journal icon on the Frame, or use the F5 key.
 
-On an XO laptop, you can press the magnifying glass key in the top row of the keyboard to immediately open the Journal and search.
+On an XO laptop, you can press the magnifying glass key in the top row of the keyboard.
 
 |journal| **Seen in an Activity**, this icon on the Activity toolbar (or Activity tab) allows quick access to the Journal, to add a description, or further notes to yourself about what you are going to do, or have done in that session of the Activity.
 
@@ -30,14 +30,14 @@ Journal features
 The Journal View contains a menu and a list of journal entries:
 
 *  1 - Favorite star: You can mark important entries by clicking on the star icon for that entry. When you click the star icon, the star is colored in.
-*  2 - Entry icon: Each Journal entry has an icon. The color of the icon shows who created the entry. For example, if you copy a photo from a friend, the photo's icon has your friend's colors. You can launch the Activity for the entry by clicking on the icon. A hover menu may reveal additional options. In particular, "Erase" deletes that entry from your Journal. Caution: "Erase" deletes any data associated with the entry shown. For example, if you delete an entry that shows that you installed an Activity, you delete the Activity as well.
-*  3 - Entry name: Each entry has a name. You can edit the name by clicking it. If the Journal view is showing the contents of a removable storage device, the Linux file name is shown here, with the path and the file name extension stripped off.
+*  2 - Entry icon: Each Journal entry has an icon. The color of the icon shows who created the entry. For example, if you copy a photo from a friend, the photo's icon has your friend's colors. You can launch the Activity for the entry by clicking on the icon. A hover menu may reveal additional options. In particular, "Erase" deletes that entry from your Journal.
+*  3 - Entry name: Each entry has a name. You can edit the name by clicking it.
 *  4 - Search box: Type words in the box to search for entries that match those words. Entries are displayed when they contain all of the typed words. Comparison will be against all of: the entry name field, the description field (see "Journal detail view"), the comments field and the tag field (see "Journal detail view"). Note: A small x button at the right of the box shows that searching is being applied. To cancel your search, click on that x.
 *  5 - Favorites view: Only shows the entries which have been marked as favorites.
-*  6 - Type filter: You can select to have the Journal only show certain types of entries, e.g. only images or only entries associated with a specific Activity.
-*  7 - Date filter: Contains option to only show Journal entries modified within the past day, week, or month.
-*  8 - Sorting options: You can order Journal entries by their size, creation date and modification date.
-*  9 - Documents folder: To exchange files between the Journal and the underlying file system the $HOME/DOCUMENTS folder is available in the Journal. For example: If you have created an image in GIMP under GNOME and want to open it in the Paint Activity you can place it in the $HOME/DOCUMENTS folder and then can access it in the Journal.
+*  6 - Type filter: You can show certain types of Journal entries, e.g. only images or only entries associated with a specific Activity.
+*  7 - Date filter: You can show certain ages of Journal entries, e.g. changed within the past day, week, or month.
+*  8 - Sorting options: You can order Journal entries by their size, creation and modification date.
+*  9 - Documents folder: To exchange files between the Journal and the underlying file system the $HOME/DOCUMENTS folder is available in the Journal. For example: If you have created an image in GIMP under GNOME and want to open it in the Paint Activity you can place it in the $HOME/DOCUMENTS folder and then access it in the Journal.
 *  10 - Buddy icons: If other participants joined you in this Activity, icons in their colors appear here.
 *  11 - Elapsed time: Displays the time since the most recent change to the entry.
 *  12 - Detail view: Click this button to see detailed information about the entry. See "Journal detail view", below. 
@@ -88,7 +88,7 @@ To remove (unmount) the external file system, choose Remove on the hover menu.
 
 Caution: It may take time for the hover menu to appear. It is easy to make a mistake and click the icon itself when you intended to click Unmount.
 
-Caution: If you have a Terminal running you may inadvertently have your removable media locked. The safest way to remove media is after powering off your computer.
+Caution: If you have a Terminal running you may inadvertently have your removable media locked. If this happens, the safest way to remove media is after powering off your computer.
 
 Sending Journal Entries via a Network
 -------------------------------------
@@ -100,6 +100,6 @@ The Journal allows you to send entries to other people who are using Sugar via a
 Note to parents and teachers
 ----------------------------
 
-The Journal keeps a record of everything a child does within Sugar: which Activities they use and what content they create. It also keeps a record of group Activities, such as participation in a shared Write or Browse session. The Journal encourages reflection. You can refer to it to assess a child's progress, much in the spirit of "portfolio" assessment. In order to further support this reflection, Sugar offers a Portfolio Activity, an assessment tool that utilizes the journal content. You can reflect on you work: what I have done; how I have done it; and how successful these efforts have been. Then you can create a multimedia presentation to share with your peers, teachers, and parents who can also reflect in return.
+The Journal keeps a record of everything a child does within Sugar: which Activities they use and what content they create. It also keeps a record of group Activities, such as participation in a shared Write or Browse session. The Journal encourages reflection. You can refer to it to assess a child's progress, much in the spirit of "portfolio" assessment. In order to further support this reflection, Sugar offers a Portfolio Activity, an assessment tool that utilizes the journal content. You can reflect on your work: what I have done; how I have done it; and how successful these efforts have been. Then you can create a multimedia presentation to share with your peers, teachers, and parents who can also reflect in return.
 
 You can also use it as a catalyst for discussion with your child or student. We encourage the use of the description field within the detail view of Journal entries as a place to annotate or comment up entries. 

--- a/source/launching_activities.rst
+++ b/source/launching_activities.rst
@@ -38,7 +38,7 @@ If you don't see the Activity's icon, click the menu icons (2) (3) to change how
 
 .. image :: ../images/Home_-_favorites_menu_annotated_800px.png
 
-In list view mode (3) you can click the star (4) next to an Activity's name to add/remove it as a favorite. Favorite Activities appear in color in the favorites view
+In list view mode (3) you can click the star (4) next to an Activity's name to add/remove it as a favorite. Favorite Activities appear in the favorites view.
 
 .. image :: ../images/Home_-_list_view_detail_annotated.png
 
@@ -71,7 +71,5 @@ Click Join in the hover menu on the Frame.
 
 .. note ::
 
-  For users
-
-  Try not to open more than three Activities at one time or your speed may be reduced.
+  Try not to open more than three Activities at one time or your computer may go slow.
 

--- a/source/my_settings.rst
+++ b/source/my_settings.rst
@@ -2,7 +2,7 @@
 My Settings
 ===========
 
-The My Settings page in Sugar is similar to a Control Panel or System Settings window in other operating systems. It provides a way to set various values needed by system functions, such as the language for menus and messages, the keyboard layout for typing and otherwise controlling the system, date and time values and format, and much more.
+The My Settings page in Sugar is similar to a Control Panel or System Settings window in other operating systems. It provides a way to view or change values needed by system functions, such as the language for menus and messages, the keyboard layout for typing and otherwise controlling the system, date and time values and format, and much more.
 
 To access My Settings, go to the Home view and activate the menu on the central XO icon, either by hovering with the cursor, or by right-clicking (O button on an XO). Then select My Settings. The following view appears.
 
@@ -15,17 +15,17 @@ Click any icon to open the indicated control. If you make changes, the window wi
 About Me
 --------
 
-View and change your XO colors and name.
+View and change your XO colors, name, gender, and grade.
 
 About my Computer
 -----------------
 
-View technical information about your computer: serial number, software versions (Sugar, firmware, wireless), copyright, and license.
+View technical information about your computer: model, serial number, software versions, copyright, and license.
 
 Background
 ----------
 
-
+Change the background image used on the Sugar views.  You can also change the opacity of the image.
 
 Date & Time
 -----------
@@ -40,17 +40,17 @@ View and set activation rules for the frame. Set the dial as to whether you woul
 Language
 --------
 
-View and set user interface language. The language you are currently using will show on line 1. If you click on the arrow at the end of the line, you can select another language. Select from the menu by country and language, or click the + icon by the last line to add another line. If there are two or more lines, a - icon will appear by the last line to allow you to delete it.
+View and set user interface languages. The language you are currently using will show on the first line, or by itself. If you click on the + at the end of the line, you can select another language. Select from the menu by country and language, or click the + icon by the last line to add another line. If there are two or more lines, a - icon will appear by the last line to allow you to delete it.
 
 Modem Configuration
 -------------------
 
-Enter settings for a mobile broadband connection to a cellular (3G) network. Not required for WiFi.
+Enter settings for a mobile broadband connection to a cellular network. Not required for WiFi.
 
 Network
 -------
 
-View and change settings for turning off wireless in order to save battery power, and view or set the jabber server name for collaboration.
+View and change settings for turning off wireless in order to save battery power, the jabber server name for collaboration, and the web site for social help.
 
 Software update
 ---------------

--- a/source/neighborhood_view.rst
+++ b/source/neighborhood_view.rst
@@ -18,14 +18,14 @@ Neighborhood Elements
 
 1.  Search menu: You can find find people, Activities, or access points (what connects you to the Internet) using the search menu.
 
-2.  Ad-Hoc network icon: An ad-hoc network lets you connect to other computers on a network. 
+2.  Ad-Hoc network icon: An ad-hoc network lets you connect to other computers without using an access point.
 
-3.  Access point: WiFi hot spots (Internet access points) appear as circles in the Neighborhood view. If you hover over a circle, the name of the network appears. Each circle has another color inside, the more full the inside color, the better the connection. To connect to a network, click the circle. If the circle shows a lock symbol, expect to enter a key or password. The inside of the circle blinks while your system tries to connect. Once you are connected, an icon for the connection will appear at bottom right of the Frame. To disconnect, hover over the circle, and choose Disconnect on the menu. Or hover over the icon in the Frame, and choose Disconnect there. (OLPC XO-1 Note: The XO-1 laptop has three mesh network channels. By clicking on a mesh icon you join that particular mesh network, and disconnect from an Access point network. The other XO icons are shown will change according to who is on that network.)
+3.  Access point: WiFi hot spots (Internet access points) appear as circles in the Neighborhood view. If you hover over a circle, the name of the network appears. Each circle has another color inside, the more full the inside color, the better the connection. To connect to a network, click the circle, and then click Connect. If the circle shows a lock symbol, expect to enter a key or password. The inside of the circle blinks while your system tries to connect. Once you are connected, an icon for the connection will appear at bottom right of the Frame. To disconnect, hover over the circle, and choose Disconnect on the menu. Or hover over the icon in the Frame, and choose Disconnect there. (OLPC XO-1 Note: The XO-1 laptop has three mesh network channels. By clicking on a mesh icon, then clicking on Connect, you join that particular mesh network, and disconnect from an Access point network. The other XO icons shown will change according to who is on that network.)
 
 4.  Shared Activities: Shared Activities appear as icons in the Neighborhood View and you can join them by clicking the corresponding icon.
 
 5.  XO icon: Other Sugar users appear as XO icons. By hovering over them, you can discover the nickname of that person and can add them as a friend or invite them to join you in a shared Activity.
 
-6.  Open access point: An access point which isn't protected by a password.
+6.  Open access point: An access point which isn't protected by a password. The network behind the access point may still have a password.
 
-7.  Connected networks: Once the computer has connected to a network 
+7.  Connected networks: Once the computer has connected to a network, two arcs are drawn either side of the icon.

--- a/source/sugar_features.rst
+++ b/source/sugar_features.rst
@@ -2,25 +2,22 @@
 Sugar Features
 ==============
 
-This page presents a number of Sugar features common to many Activities. The page is designed as a series of "reference topics".
-
-This experimental page includes graphical spacers to separate non-related topics.
-
+This page presents a number of Sugar features common to many Activities.
 .. _View source:
 
 View source
 -----------
 
-You always can view the source code of Sugar Activities. In most cases, View Source will show you the python code of the activity, in other cases, like Browse, you can see the HTML code of the page seen in the activity.
+You always can view the source code of Sugar Activities. In most cases, View Source will show you the Python code of the activity, in other cases, like Browse, you can see the HTML code of the page seen in the activity.
 
-You can see the source window pressing Fn-space in your XO or Ctrl-Shift-V or pressing right click on the Activity's icon in the :doc:`/frame`. Here is an example of viewing the source of a page in :doc:`/help` Activity. In the case of this activity, you see the simple text, which Help converts into HTML pages for display. This is useful in the process of editing Help pages as described here :doc:`/how_to_help`
+You can see the source window by pressing Fn-space on your XO, or Alt-Shift-V, or right click on the Activity's icon in :doc:`/frame`. Here is an example of viewing the source of a page in :doc:`/help` Activity. In the case of this activity, you see the simple text, which Help converts into HTML pages for display. This is useful in the process of editing Help pages as described in :doc:`/how_to_help`.
 
 .. image :: ../images/HelpFrame.png
 
 Duplicating activities
 ----------------------
 
-A option to duplicate an activity has been added to the View Source alert. By selecting this option, a copy of the activity is created in the user's $HOME/Activities directory. Thus we hope to encourage Sugar users to make modifications and improvements to the code they use without the risk of breaking the original activity.
+In the source window is an option to duplicate an activity. By selecting this option, a copy of the activity is created in the user's $HOME/Activities directory. Thus we hope to encourage Sugar users to make modifications and improvements to the code they use without the risk of breaking the original activity.
 
 .. image :: ../images/300px-Duplicate_activity.png
 
@@ -30,10 +27,6 @@ A option to duplicate an activity has been added to the View Source alert. By se
 
 The Sugarlabs.org wiki has a informative article: http://wiki.sugarlabs.org/go/View_Source
 
-
-*End of topic - spacer below.*
-
-.. image :: ../images/spacer600.png
 
 .. _say_selected_text:
 


### PR DESCRIPTION
- add activity search result unique feature, new in 0.104 or 0.106,

- add Social Help server to Network control panel, new in 0.106,

- add F5 key as shortcut for Frame,

- add gender and grade to About Me,

- add model to About my Computer,

- explain Background control panel,

- correct Language control panel usage,

- drop 3G reference in Modem Configuration control panel; same applies
  for other technologies now,

- view source is Alt/Shift/V not Ctrl/Shift/V,

- exiting activities is by convention a "stop" not a "quit",

- add Terminal activity stop documentation,

- add MATE desktop reference for 2014 Fedora 20 builds by OLPC,

- better definition of ad-hoc; sans access point,

- add missing text describing connected network icon, two arcs,

- some language simplification.

Signed-off-by: James Cameron <quozl@laptop.org>