### PR TITLE
Fix issue#44

### DIFF
--- a/source/abacus_worksheet.rst
+++ b/source/abacus_worksheet.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. _abacus-worksheet:
 
 Fractions

--- a/source/abacus_worksheet_answers.rst
+++ b/source/abacus_worksheet_answers.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. _abacus-worksheet-answersheet:
 
 Answers to the Abacus Worksheet

--- a/source/turtleart_challenges.rst
+++ b/source/turtleart_challenges.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. _turtleart-challenges:
 
 Challenges


### PR DESCRIPTION
Commit fixes the warnings generated by the following 3 files as reported in issue#44 
- source/abacus_worksheet.rst
- source/abacus_worksheet_answers.rst
- source/turtleart_challenges.rst

Edit: The warning system in Sphinx seemed a bit erratic in my system. As in the process of fixing the following, the warnings kept popping in and out. It would be very helpful if anyone confirms that the issue is actually fixed by implementing the same. Thank you. 