### PR TITLE
migrate Activities/Typing_Turtle from wiki

### DIFF
--- a/helplink.json
+++ b/helplink.json
@@ -48,5 +48,6 @@
     "org.laptop.TurtleArtActivity3D": "turtleblocks3d.html",
     "org.laptop.TurtleConfusionActivity": "turtle_confusion.html",
     "org.sugarlabs.TurtlePondActivity": "turtle_in_a_pond.html",
+    "org.laptop.community.TypingTurtle": "typing_turtle.html",
     "org.laptop.AbiWordActivity": "write.html"
   }

--- a/source/index.rst
+++ b/source/index.rst
@@ -85,6 +85,7 @@ Activities
     turtleblocks3d.rst
     turtle_confusion.rst
     turtle_in_a_pond.rst
+    typing_turtle.rst
     write.rst
 
 

--- a/source/typing_turtle.rst
+++ b/source/typing_turtle.rst
@@ -1,0 +1,30 @@
+.. _typing-turtle:
+
+=============
+Typing Turtle
+=============
+
+Typing Turtle is available from the `Sugar Labs Activity Library <http://activities.sugarlabs.org/en-US/sugar/addon/4026>`__.
+
+Typing Turtle is an interactive touch typing program. It gradually
+introduces the keys on the keyboard through a series of lessons, until
+the student has learned the entire keyboard. Skills are reinforced with
+typing games.
+
+Screenshots
+-----------
+
+Screenshots can be found at the `Activity
+page <http://activities.sugarlabs.org/en-US/sugar/addon/4026>`__.
+
+Features
+--------
+
+-  An on-screen keyboard with overlaid hand positions shows the correct
+   way to press each key, encouraging good typing habits.
+-  Automatically picks up and uses the system's keyboard layout.
+-  You can make your own lessons, and send them to students or friends.
+-  A balloon game provides an entertaining way to gain skill.
+-  Medals are awarded as the user completes the lessons. Gold is for the
+   best accuracy and speed, followed by Silver and Bronze.
+


### PR DESCRIPTION
This Pull Request migrates documentation from

1. https://wiki.sugarlabs.org/go/Activities/Typing_Turtle

Steps to perform after this Pull Request gets merged:
- [ ] Deprecate wiki-page 1
- [ ] Add README to [typing-turtle-activity](https://github.com/sugarlabs/typing-turtle-activity) which points to this user documentation.
- [ ] Add Localization tips to [typing-turtle-activity](https://github.com/sugarlabs/typing-turtle-activity) (as available at 1)