### PR TITLE
Update Chat documentation

### DIFF
--- a/source/chat.rst
+++ b/source/chat.rst
@@ -1,3 +1,5 @@
+.. _chat:
+
 ====
 Chat
 ====
@@ -8,6 +10,15 @@ About
 The Chat Activity is used to exchange messages with your friends or classmates. You can chat about a topic you are studying or you can share something private that happened in your life. You need at least two active XOs to chat - your own and the one that your friend uses.
 
 .. image :: ../images/chat_index.png
+
+Where to get Chat
+-----------------
+
+Chat activity is available for download from the `Sugar Activity Library <http://activities.sugarlabs.org>`__: 
+`Chat <https://activities.sugarlabs.org/en-US/sugar/addon/4069>`__
+
+The source code is available on `GitHub <https://github.com/sugarlabs/chat>`__.
+
 
 Using Chat
 ----------
@@ -208,3 +219,8 @@ Note to parents and teachers
 ::::::::::::::::::::::::::::
 
 You can use this feature to chat with Sugar-enabled computers from non-Sugar-enabled computers; hence you can chat with your child or class from a conventional desktop or laptop computer.
+
+Reporting Problems
+------------------
+
+Please report bugs and make feature requests at `chat/issues <https://github.com/sugarlabs/chat/issues>`__.


### PR DESCRIPTION
This Pull Request migrates documentation from

1. https://wiki.sugarlabs.org/go/Activities/Chat

Most of the content was already available at the help-activity via https://github.com/godiard/help-activity/commit/cab47939a5a446d909281711d9da9a0cfb2fc0ed#diff-a63c7837ca2e26bae269275c8599f4ac

Added sections:
* Where to get Chat
* Reporting Problems

Steps to perform after this Pull Request gets merged:
- [ ] Redirect wiki-page 1
- [ ] Add README to [sugarlabs/chat](https://github.com/sugarlabs/chat)
- [ ] Update screenshots in [sugarlabs/chat](https://github.com/sugarlabs/chat); if required