### PR TITLE
Update Write documentation

### DIFF
--- a/source/write.rst
+++ b/source/write.rst
@@ -1,3 +1,5 @@
+.. _write:
+
 =====
 Write
 =====
@@ -12,6 +14,14 @@ Write utilizes the :doc:`/journal`, your work is automatically saved, and :ref:`
 The Write Activity can be used to open and edit most common file formats, including ODT, DOC, RTF, TXT, and HTML.
 
 Write is included in OLPC images and can be downloaded from `ASLO <http://activities.sugarlabs.org>`_, search for Paint.
+
+Where to get Write
+------------------
+
+Write activity is available for download from the `Sugar Activity Library <http://activities.sugarlabs.org>`__: 
+`Write <https://activities.sugarlabs.org/en-US/sugar/addon/4201>`__
+
+The source code is available on `GitHub <https://github.com/sugarlabs/write-activity>`__.
 
 Using
 -----
@@ -238,6 +248,11 @@ Other learning activities
 * Write an autobiography.
 * Interview someone from your community.
 * Write an article for the Wikipedia about your community.
+
+Where to report problems
+------------------------
+
+Please report bugs and make feature requests at `write-activity/issues <https://github.com/sugarlabs/write-activity/issues>`__.
 
 Credits
 -------


### PR DESCRIPTION
This Pull Request migrates documentation from

1. https://wiki.sugarlabs.org/go/Activities/Write

Updated content was already available at the help-activity via https://github.com/godiard/help-activity/commit/cab47939a5a446d909281711d9da9a0cfb2fc0ed#diff-d76793ffb62f9c30334d5c1bfdb3180e

Added
* 'Where to get Write' section
* 'Where to report problems' section

Steps to perform after this Pull Request gets merged:
- [ ] Redirect wiki-page 1