### PR TITLE
Update Terminal documentation

### DIFF
--- a/source/terminal.rst
+++ b/source/terminal.rst
@@ -1,3 +1,5 @@
+.. _terminal-activity:
+
 ========
 Terminal
 ========
@@ -78,3 +80,8 @@ See the FLOSS Manuals manuals
 
 * `Terminal <http://en.flossmanuals.net/terminal/>`_ about the Sugar Terminal activity
 * `Introduction to the Command Line <http://en.flossmanuals.net/command-line/>`_ for a user's tutorial on command line functions 
+
+Where to report problems
+------------------------
+
+Please report bugs and make feature requests at `terminal-activity/issues <https://github.com/sugarlabs/terminal-activity/issues>`__.


### PR DESCRIPTION
This Pull Request migrates documentation from

1. https://wiki.sugarlabs.org/go/Activities/Terminal

Updated content was already available at the help-activity via https://github.com/godiard/help-activity/commit/cab47939a5a446d909281711d9da9a0cfb2fc0ed#diff-ef69dd916df95b76e8536826537c6634

Added
* 'Where to report problems' section

Steps to perform after this Pull Request gets merged:
- [ ] Redirect wiki-page 1