### PR TITLE
Update Distance documentation

### DIFF
--- a/source/distance.rst
+++ b/source/distance.rst
@@ -1,3 +1,5 @@
+.. _distance:
+
 ========
 Distance
 ========
@@ -10,12 +12,13 @@ Distance (earlier known as Acoustic Tape Measure) determines the physical distan
 .. image :: ../images/distance_img1.png
 
 
-Download
---------
+Where to get Distance
+---------------------
 
-* `Activity page in our activities portal <http://activities.sugarlabs.org/en-US/sugar/addon/4264>`_
+Distance activity is available for download from the `Sugar Activity Library <http://activities.sugarlabs.org>`__: 
+`Distance <http://activities.sugarlabs.org/en-US/sugar/addon/4264>`__
 
-* `Git Repository <http://git.sugarlabs.org/distance>`_
+The source code is available on `GitHub <https://github.com/sugarlabs/distance-activity>`__.
 
 
 Using Distance
@@ -60,15 +63,79 @@ Notes
 * The Paste button found on the Edit toolbar can be used to paste a new measurement unit into the activity. The scale of the measurement units should be specified in terms of meters, e.g., 39.37 for specifying inches. 
 
 
-Reporting problems
-------------------
-`File Bug Report <https://bugs.sugarlabs.org/newticket?component=Distance>`_
+For more information about the internals, please see `Measurement Algorithm <http://wiki.laptop.org/go/Distance#Measurement_Algorithm>`__
+
+For some ideas on how to use Distance, please see `Ideas for use <http://wiki.laptop.org/go/Distance#Ideas_for_use>`__
+
+
+Just for fun
+------------
+
+When he heard about the feature in the Distance activity that allows one to define new metrics on the fly, Chris Leonard sent these units for consideration:
+
+New measures:
+
+1. Ratio of an igloo's circumference to its diameter = Eskimo Pi
+
+2. 2000 pounds of Chinese soup = Won Ton
+
+3. 1 millionth of a mouthwash = 1 microscope
+
+4. Time between slipping on a peel and smacking the pavement = 1 bananosecond
+
+5. Weight an evangelist carries with God = 1 billigram
+
+6. Time it takes to sail 220 yards at 1 nautical-mile per hour = Knotfurlong
+
+7. 16.5 feet in the Twilight Zone = 1 Rod Sterling
+
+8. Half of a large intestine = 1 semicolon
+
+9. 1,000,000 aches = 1 megahurtz
+
+10. Basic unit of laryngitis = 1 hoarsepower
+
+11. Shortest distance between two jokes = A straight line
+
+12. 453.6 graham crackers = 1 pound cake
+
+13. 1-million-million microphones = 1 megaphone
+
+14. 2-million bicycles = 2 megacycles
+
+15. 365.25 days = 1 unicycle
+
+16. 2000 mockingbirds = 2 kilomockingbirds
+
+17. 52 cards = 1 decacards
+
+18. 1 kilogram of falling figs = 1 Fig Newton
+
+19. 1000 milliliters of wet socks = 1 literhosen
+
+20. 1 millionth of a fish = 1 microfiche
+
+21. 1 trillion pins = 1 terrapin
+
+22. 10 rations = 1 decoration
+
+23. 100 rations = 1 C-ration
+
+24. 2 monograms = 1 diagram
+
+25. 4 nickels = 2 paradigms
+
+26. 2.4 statute miles of intravenous surgical tubing at Yale University Hospital = 1 IV League
+
+27. 100 Senators = Not 1 decision
+
+
+Where to report problems
+------------------------
+
+Please report bugs and make feature requests at `distance-activity <https://github.com/sugarlabs/distance-activity/issues>`__.
+
 
 Credits
 -------
 Distance was written by Benjamin Schwartz. It is maintained by Rafael Ortiz and Walter Bender 
-
-
-References
-----------
-`Wiki Page <http://wiki.sugarlabs.org/go/Activities/Distance>`_


### PR DESCRIPTION
This Pull Request migrates documentation from

1. https://wiki.sugarlabs.org/go/Activities/Distance

Content was already available at the help-activity via https://github.com/godiard/help-activity/commit/fb8837e120ae777681aeabe6501fd67f6ea0bdc5

Added
* 'Just for fun' section
* links to [distance-activity](https://github.com/sugarlabs/distance-activity)

Removed
* references to wiki

Steps to perform after this Pull Request gets merged:
- [ ] Redirect wiki-page 1
- [x] Add README to [distance-activity](https://github.com/sugarlabs/distance-activity)
