### PR TITLE
Migrate Activities/Sugar_Commander from Wiki

### DIFF
--- a/helplink.json
+++ b/helplink.json
@@ -48,6 +48,7 @@
     "org.laptop.StarChart": "starchart.html",
     "org.laptop.StopWatchActivity": "stopwatch.html",
     "org.sugarlabs.StoryActivity": "story.html",
+    "org.laptop.sugar.SugarCommander": "sugar_commander.html",
     "org.laptop.TamTamMini": "tamtammini.html",
     "org.laptop.Terminal": "terminal.html",
     "org.laptop.TurtleArtActivity": "turtleart.html",

--- a/source/index.rst
+++ b/source/index.rst
@@ -85,6 +85,7 @@ Activities
     starchart.rst
     stopwatch.rst
     story.rst
+    sugar_commander.rst
     tamtammini.rst
     terminal.rst
     turtleart.rst

--- a/source/sugar_commander.rst
+++ b/source/sugar_commander.rst
@@ -1,0 +1,38 @@
+.. _sugar-commander:
+
+===============
+Sugar Commander
+===============
+
+Sugar Commander is a utility Activity that improves the experience of
+working with the Journal. It can do most things the Journal Activity
+itself can do with the exception of resuming Activities and copying
+Journal entries to files. (These functions are forbidden to ordinary
+Activities by Sugar).
+
+Where to get Sugar Commander
+----------------------------
+
+Sugar Commander activity is available for download from the `Sugar Activity Library <http://activities.sugarlabs.org/en-US/sugar/>`__:
+`Sugar Commander <http://activities.sugarlabs.org/en-US/sugar/addon/4291>`__
+
+The source code is available on `GitHub <https://github.com/sugarlabs/sugar-commander>`__.
+
+
+Current Features
+----------------
+
+Unlike the Journal Activity, which represents the contents of thumb
+drives and SD cards as if they were Journal entries, this Activity has a
+tab for files and directories and another tab for Journal entries. You
+can choose a file from anywhere in the file system and add it to the
+Journal as an entry. You can browse the Journal sorted by title or MIME
+type. You can select Journal entries and edit the title, description,
+and tags, plus see the preview image, without opening a new window. You
+can also delete Journal entries you don't want.
+
+
+Where to report problems
+------------------------
+
+Please report bugs and make feature requests at `sugar-commander/issues <https://github.com/sugarlabs/sugar-commander/issues>`__.


### PR DESCRIPTION
This Pull Request migrates documentation from

1. https://wiki.sugarlabs.org/go/Activities/Sugar_Commander

Steps to perform after this Pull Request gets merged:
- [ ] Redirect wiki-page 1
- [ ] Add README to [sugar-commander](https://github.com/sugarlabs/sugar-commander) which points to this user documentation.