### PR TITLE
Update Poll documentation

### DIFF
--- a/source/poll.rst
+++ b/source/poll.rst
@@ -1,3 +1,5 @@
+.. _poll:
+
 ====
 Poll
 ====
@@ -5,6 +7,18 @@ Poll
 Overview
 --------
 A poll is a research tool that helps explain what a group of people think about a subject.  First you present the group with a question and a set of answer choices. Then each person in the group gets to vote for the answer which best describes their personal feelings or opinion.  After collecting votes from the whole group, you look for a pattern in their answers.  You can also ask the same question of different groups (i.e. boys and girls or children and adults) and see how each group answers.
+
+Where to get Poll
+-----------------
+
+Poll activity is available for download from the `Sugar Activity Library <http://activities.sugarlabs.org/en-US/sugar/>`__:
+`Poll <http://activities.sugarlabs.org/en-US/sugar/addon/4074>`__
+
+The source code is available on `GitHub <https://github.com/godiard/poll-activity>`__.
+
+
+How to use
+----------
 
 A poll can be used to help a community make a decision and take action.  It can also be used to understand the similarities and differences among individuals and groups of people.
 
@@ -128,3 +142,9 @@ On the other laptops in the same wireless network;
 * cast your vote.
 
 Be careful with counting.  You and others who have joined the activity can vote more than once.
+
+
+Where to report problems
+------------------------
+
+Please report bugs and make feature requests at `poll-activity/issues <https://github.com/godiard/poll-activity/issues>`__.


### PR DESCRIPTION
This Pull Request migrates documentation from

1. https://wiki.sugarlabs.org/go/Activities/Poll

Content was already available at the help-activity via https://github.com/godiard/help-activity/commit/ad2fce7ea36cdcf8c14a4f8abc8e43529b5b13fc

added
- 'Where to get Poll' section
- 'Where to report problems' section

Steps to perform after this Pull Request gets merged:
- [ ] Redirect wiki-page 1
- [ ] Add README to [poll-activity](https://github.com/godiard/poll-activity)


