### PR TITLE
Update IRC documentation

### DIFF
--- a/source/irc.rst
+++ b/source/irc.rst
@@ -1,3 +1,5 @@
+.. _irc:
+
 ===
 IRC
 ===
@@ -5,15 +7,27 @@ IRC
 About
 -----
 
-|IRC_icon| The IRC activity allows you to chat with other Sugar/OLPC users and enthusiasts on the Internet via Internet Relay Chat (IRC).
+|IRC_icon|
+
+The IRC activity allows you to chat with other Sugar/OLPC users and enthusiasts on the Internet via `Internet Relay Chat <https://en.wikipedia.org/wiki/Internet_Relay_Chat>`_ (IRC).
 
 .. |IRC_icon| image:: ../images/irc-icon.png
 
-The activity defaults to a "channel" (akin to a "room") called #sugar on the Freenode network, but you can join one of the many channels available by typing /join #channel, where #channel is the channel name. Like many Free/Open Source projects, Sugar developers frequent this channel, and are happy to help with any Sugar questions and suggestions you may have.
+The activity defaults to a "channel" (akin to a "room") called #sugar on the `Freenode <https://freenode.net/>`_ network, but you can join one of the many channels available by typing ``/join #channel``, where **#channel** is the channel name. Like many Free/Open Source projects, `Sugar <https://wiki.sugarlabs.org/go/Sugar>`_ developers frequent this channel, and are happy to help with any Sugar questions and suggestions you may have.
 
 See the Internet Relay Chat page on `this wiki <http://wiki.sugarlabs.org/go/Internet_Relay_Chat>`_ for a list of Sugar-related channels you can join.
 
 .. image :: ../images/irc-image1.png
+
+
+Where to get IRC
+----------------
+
+IRC activity is available for download from the `Sugar Activity Library <http://activities.sugarlabs.org/en-US/sugar/>`__:
+`IRC <http://activities.sugarlabs.org/en-US/sugar/addon/4029>`__
+
+The source code is available on `GitHub <https://github.com/sugarlabs/irc-activity>`__.
+
 
 Using IRC
 ---------
@@ -23,29 +37,20 @@ IRC Commands
 
 The following commands can be typed into the input box, all preceded by a slash (/):
 
-* /join #channel - join a channel
+* ``/join #channel`` - join a channel
 
-* /server irc.example.org - connect to a different network
+* ``/server irc.example.org`` - connect to a different network
 
-* /query user - open up a private chat window with another user
+* ``/query user`` - open up a private chat window with another user
 
-* /msg user message - privately message another user without opening a new window
+* ``/msg user message`` - privately message another user without opening a new window
 
-* /nick new_name - change your nickname away from the default
+* ``/nick new_name`` - change your nickname away from the default
 
-Many other commands are available, and you can create and administer your own channels as well: see the `IRC FAQ <http://www.irchelp.org/irchelp/altircfaq.html>`_ for more information.
-
-
-Download
---------
-`ASLO IRC <http://activities.sugarlabs.org/sugar/addon/4029>`_
+Many other commands are available, and you can create and administer your own channels as well: see the `IRC Help <http://www.irchelp.org>`_ for more information.
 
 
-Development
------------
-`Git Repository <http://git.sugarlabs.org/projects/irc>`_
+Where to report problems
+------------------------
 
-
-References
-----------
-`Wiki Page <http://wiki.sugarlabs.org/go/Activities/IRC>`_
+Please report bugs and make feature requests at `irc-activity/issues <https://github.com/sugarlabs/irc-activity/issues>`__.


### PR DESCRIPTION
This Pull Request migrates documentation from

1. https://wiki.sugarlabs.org/go/Activities/IRC

Content was already available at the help-activity via https://github.com/godiard/help-activity/commit/196b538f60563de64928153655c1ef3fa56040fd

- added 'Where to get IRC' section
- added 'Where to report problems' section
- added links to keywords used in page
- updated broken links
- removed wiki references

Steps to perform after this Pull Request gets merged:
- [ ] Redirect wiki-page 1