### PR TITLE
Update Measure documentation

### DIFF
--- a/source/measure.rst
+++ b/source/measure.rst
@@ -1,3 +1,5 @@
+.. _measure:
+
 =======
 Measure
 =======
@@ -12,6 +14,16 @@ As well as graphing signal as a function of time, Measure can also graph as a fu
 The XO-1 laptop is only capable of mono input, the XO-1.5 and XO-1.75 are capable of stereo input on their microphone socket and can graph two signals at once.
 
 .. image :: ../images/200px-Measure_tut_1_24.jpg
+
+
+Where to get Measure
+--------------------
+
+Measure activity is available for download from the `Sugar Activity Library <http://activities.sugarlabs.org/en-US/sugar/>`__:
+`Measure <http://activities.sugarlabs.org/en-US/sugar/addon/4197>`__
+
+The source code is available on `GitHub <https://github.com/sugarlabs/Measure>`__.
+
 
 Using
 -----
@@ -81,3 +93,9 @@ Care should be taken not to exceed the allowable input voltage:
 It is a good idea, particularly on the XO-1, to put a resistor of 680 ohms in the phono plug, this increases the allowable input voltage range.
 
 You can find ideas for fun science experiments at http://wiki.sugarlabs.org/go/Activities/TurtleArt/Using_Turtle_Art_Sensors and http://wiki.laptop.org/go/Measure 
+
+
+Where to report problems
+------------------------
+
+Please report bugs and make feature requests at `Measure/issues <https://github.com/sugarlabs/Measure/issues>`__.


### PR DESCRIPTION
This Pull Request migrates documentation from

1. https://wiki.sugarlabs.org/go/Activities/Measure

Content was already available at the help-activity via https://github.com/godiard/help-activity/commit/cab47939a5a446d909281711d9da9a0cfb2fc0ed#diff-376da021b48a58f301c68a5d20674f72

added
- 'Where to get Measure' section
- 'Where to report problems' section

Steps to perform after this Pull Request gets merged:
- [ ] Redirect wiki-page 1